### PR TITLE
fix: Сделано обязательным поле device в NLPRequest

### DIFF
--- a/packages/scenario/src/lib/types/request.ts
+++ b/packages/scenario/src/lib/types/request.ts
@@ -14,10 +14,8 @@ export interface NLPRequestBody<T, P> extends Pick<SystemMessage, 'sessionId' | 
     payload: P;
 }
 
-export type SharedRequestPayload = Pick<
-    SystemMessagePayload,
-    'device' | 'app_info' | 'projectName' | 'strategies' | 'character'
->;
+export type SharedRequestPayload = Pick<SystemMessagePayload, 'app_info' | 'projectName' | 'strategies' | 'character'> &
+    Required<Pick<SystemMessagePayload, 'device'>>;
 
 export type MTSPayload = SharedRequestPayload &
     Pick<
@@ -144,4 +142,5 @@ export type NLPRequestTPD = NLPRequestBody<
     }
 >;
 
+// Запрос, который получает навык от NLP
 export type NLPRequest = NLPRequestRA | NLPRequestСA | NLPRequestMTS | NLPRequestSA | NLPRequestTPD;

--- a/packages/scenario/src/lib/types/response.ts
+++ b/packages/scenario/src/lib/types/response.ts
@@ -103,6 +103,7 @@ export type NLPResponseGDPD = NLPResponseBody<
     SharedResponsePayload & ProfileDataPayloadFieldsType
 >;
 
+// Ответ, который получает NLP от навыка
 export type NLPResponse =
     | NLPResponseATU
     | NLPResponseE


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/recognizer-smartapp-brain@0.26.1-canary.12.2718756742.0
  npm install @salutejs/recognizer-string-similarity@0.26.1-canary.12.2718756742.0
  npm install @salutejs/scenario@0.26.1-canary.12.2718756742.0
  npm install @salutejs/storage-adapter-firebase@0.26.1-canary.12.2718756742.0
  npm install @salutejs/storage-adapter-memory@0.26.1-canary.12.2718756742.0
  # or 
  yarn add @salutejs/recognizer-smartapp-brain@0.26.1-canary.12.2718756742.0
  yarn add @salutejs/recognizer-string-similarity@0.26.1-canary.12.2718756742.0
  yarn add @salutejs/scenario@0.26.1-canary.12.2718756742.0
  yarn add @salutejs/storage-adapter-firebase@0.26.1-canary.12.2718756742.0
  yarn add @salutejs/storage-adapter-memory@0.26.1-canary.12.2718756742.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
