### PR TITLE
new_session приходит в каждом сообщении

### DIFF
--- a/packages/scenario/src/lib/types/request.ts
+++ b/packages/scenario/src/lib/types/request.ts
@@ -15,19 +15,12 @@ export interface NLPRequestBody<T, P> extends Pick<SystemMessage, 'sessionId' | 
 }
 
 export type SharedRequestPayload = Pick<SystemMessagePayload, 'app_info' | 'projectName' | 'strategies' | 'character'> &
-    Required<Pick<SystemMessagePayload, 'device'>>;
+    Required<Pick<SystemMessagePayload, 'device' | 'new_session'>>;
 
 export type MTSPayload = SharedRequestPayload &
     Pick<
         SystemMessagePayload,
-        | 'intent'
-        | 'original_intent'
-        | 'intent_meta'
-        | 'meta'
-        | 'selected_item'
-        | 'new_session'
-        | 'annotations'
-        | 'message'
+        'intent' | 'original_intent' | 'intent_meta' | 'meta' | 'selected_item' | 'annotations' | 'message'
     >;
 
 /** MESSAGE_TO_SKILL */


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/recognizer-smartapp-brain@0.26.4-canary.19.3298032487.0
  npm install @salutejs/recognizer-string-similarity@0.26.4-canary.19.3298032487.0
  npm install @salutejs/scenario@0.26.4-canary.19.3298032487.0
  npm install @salutejs/storage-adapter-firebase@0.26.4-canary.19.3298032487.0
  npm install @salutejs/storage-adapter-memory@0.26.4-canary.19.3298032487.0
  # or 
  yarn add @salutejs/recognizer-smartapp-brain@0.26.4-canary.19.3298032487.0
  yarn add @salutejs/recognizer-string-similarity@0.26.4-canary.19.3298032487.0
  yarn add @salutejs/scenario@0.26.4-canary.19.3298032487.0
  yarn add @salutejs/storage-adapter-firebase@0.26.4-canary.19.3298032487.0
  yarn add @salutejs/storage-adapter-memory@0.26.4-canary.19.3298032487.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
