### PR TITLE
Вызывать run_app только c messageName=RUN_APP

### DIFF
--- a/packages/scenario/src/lib/createScenarioWalker.ts
+++ b/packages/scenario/src/lib/createScenarioWalker.ts
@@ -134,8 +134,10 @@ export const createScenarioWalker = ({
             return;
         }
 
-        await systemScenario.RUN_APP(saluteHandlerOpts, dispatch);
-        return;
+        if (req.request.messageName !== 'MESSAGE_TO_SKILL') {
+            await systemScenario.RUN_APP(saluteHandlerOpts, dispatch);
+            return;
+        }
     }
 
     if (req.systemIntent === 'close_app') {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/recognizer-smartapp-brain@0.28.0-canary.23.3359574946.0
  npm install @salutejs/recognizer-string-similarity@0.28.0-canary.23.3359574946.0
  npm install @salutejs/scenario@0.28.0-canary.23.3359574946.0
  npm install @salutejs/storage-adapter-firebase@0.28.0-canary.23.3359574946.0
  npm install @salutejs/storage-adapter-memory@0.28.0-canary.23.3359574946.0
  # or 
  yarn add @salutejs/recognizer-smartapp-brain@0.28.0-canary.23.3359574946.0
  yarn add @salutejs/recognizer-string-similarity@0.28.0-canary.23.3359574946.0
  yarn add @salutejs/scenario@0.28.0-canary.23.3359574946.0
  yarn add @salutejs/storage-adapter-firebase@0.28.0-canary.23.3359574946.0
  yarn add @salutejs/storage-adapter-memory@0.28.0-canary.23.3359574946.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
