### PR TITLE
fix: добавить бумы в surface

### DIFF
--- a/packages/scenario/src/lib/types/systemMessage.ts
+++ b/packages/scenario/src/lib/types/systemMessage.ts
@@ -211,7 +211,18 @@ export type PlatformType = 'android' | 'ios' | 'web' | 'WEBDBG';
 /**
  * Поверхность, от которой приходит вызов ассистента. Например, приложение СберБанк Онлайн или SberBox.
  */
-export type Surface = 'SBERBOX' | 'COMPANION' | 'STARGATE' | 'SATELLITE' | 'TIME' | 'SBOL' | 'TV' | 'TV_HUAWEI';
+export type Surface =
+    | 'SBERBOX'
+    | 'SBERBOOM'
+    | 'SBERBOOM_MINI'
+    | 'SBERBOOM_R2'
+    | 'COMPANION'
+    | 'STARGATE'
+    | 'SATELLITE'
+    | 'TIME'
+    | 'SBOL'
+    | 'TV'
+    | 'TV_HUAWEI';
 /**
  * Идентификатор персонажа, которого выбрал пользователь.
  */
@@ -2793,6 +2804,9 @@ export interface Hint {
  */
 export const DefaultChannels: Record<Surface, UserChannel> = {
     SBERBOX: 'B2C',
+    SBERBOOM: 'B2C',
+    SBERBOOM_MINI: 'B2C',
+    SBERBOOM_R2: 'B2C',
     STARGATE: 'B2C',
     SATELLITE: 'B2C',
     TIME: 'B2C',


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/recognizer-smartapp-brain@0.39.1-canary.95.6083872220.0
  npm install @salutejs/recognizer-string-similarity@0.39.1-canary.95.6083872220.0
  npm install @salutejs/scenario@0.39.1-canary.95.6083872220.0
  npm install @salutejs/storage-adapter-firebase@0.39.1-canary.95.6083872220.0
  npm install @salutejs/storage-adapter-memory@0.39.1-canary.95.6083872220.0
  # or 
  yarn add @salutejs/recognizer-smartapp-brain@0.39.1-canary.95.6083872220.0
  yarn add @salutejs/recognizer-string-similarity@0.39.1-canary.95.6083872220.0
  yarn add @salutejs/scenario@0.39.1-canary.95.6083872220.0
  yarn add @salutejs/storage-adapter-firebase@0.39.1-canary.95.6083872220.0
  yarn add @salutejs/storage-adapter-memory@0.39.1-canary.95.6083872220.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
